### PR TITLE
Fix handling jars without manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ val functionalTestSourceSet = sourceSets.create("functionalTest") {
 gradlePlugin.testSourceSets(functionalTestSourceSet)
 configurations.getByName("functionalTestImplementation").extendsFrom(configurations.getByName("testImplementation"))
 val functionalTest by tasks.creating(Test::class) {
+    group = "verification"
     testClassesDirs = functionalTestSourceSet.output.classesDirs
     classpath = functionalTestSourceSet.runtimeClasspath
 }


### PR DESCRIPTION
An example of such a jar: https://repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar

P.S. I know that there's a properly modularized Jakarta EE replacement, but I believe the plugin should still support the subject and do not throw an NPE if it encounters a jar like that. 