### PR TITLE
Add support for provides with/requires static declarations

### DIFF
--- a/src/functionalTest/groovy/de/jjohannes/gradle/javamodules/test/ExtraJavaModuleInfoTest.groovy
+++ b/src/functionalTest/groovy/de/jjohannes/gradle/javamodules/test/ExtraJavaModuleInfoTest.groovy
@@ -291,6 +291,72 @@ class ExtraJavaModuleInfoTest extends Specification {
         build().task(':compileJava').outcome == TaskOutcome.SUCCESS
     }
 
+    def "can retrofit META-INF/services/* metadata to module-info.class"() {
+        given:
+        new File(testFolder.root, "src/main/java/org/gradle/sample/app/data").mkdirs()
+
+        testFolder.newFile("src/main/java/org/gradle/sample/app/Main.java") << """
+            package org.gradle.sample.app;
+            
+            import java.util.ServiceLoader;
+            import java.util.stream.Collectors;
+            import org.apache.logging.log4j.spi.Provider;
+            
+            public class Main {
+            
+                public static void main(String[] args)  {
+                    Provider provider = ServiceLoader.load(Provider.class).findFirst()
+                                        .orElseThrow(() -> new AssertionError("No providers loaded"));
+                    System.out.println(provider.getClass());
+                }
+                          
+            }
+        """
+        testFolder.newFile("src/main/java/module-info.java") << """
+            module org.gradle.sample.app {               
+                requires org.apache.logging.log4j;
+                requires org.apache.logging.log4j.core;
+                
+                uses org.apache.logging.log4j.spi.Provider;                              
+            }
+        """
+        testFolder.newFile("build.gradle.kts") << """
+            plugins {
+                application
+                id("de.jjohannes.extra-java-module-info")
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            java {
+                modularity.inferModulePath.set(true)
+            }
+            
+            dependencies {
+                implementation("org.apache.logging.log4j:log4j-core:2.14.0")                     
+            }
+            
+            extraJavaModuleInfo {               
+                module("log4j-core-2.14.0.jar", "org.apache.logging.log4j.core", "2.14.0") {
+                    requires("java.compiler")
+                    requires("java.desktop")
+                    requires("org.apache.logging.log4j")
+                    exports("org.apache.logging.log4j.core")
+                }
+            }
+                                 
+            application {
+                mainModule.set("org.gradle.sample.app")
+                mainClass.set("org.gradle.sample.app.Main")
+            }
+        """
+
+        expect:
+        run().task(':run').outcome == TaskOutcome.SUCCESS
+    }
+
     def "fails by default if no module info is defined for a legacy library"() {
         given:
         new File(testFolder.root, "src/main/java").mkdirs()
@@ -422,6 +488,10 @@ class ExtraJavaModuleInfoTest extends Specification {
 
     BuildResult build() {
         gradleRunnerFor(['build']).build()
+    }
+
+    BuildResult run() {
+        gradleRunnerFor(['run']).build()
     }
 
     BuildResult fail() {

--- a/src/functionalTest/groovy/de/jjohannes/gradle/javamodules/test/ExtraJavaModuleInfoTest.groovy
+++ b/src/functionalTest/groovy/de/jjohannes/gradle/javamodules/test/ExtraJavaModuleInfoTest.groovy
@@ -357,6 +357,84 @@ class ExtraJavaModuleInfoTest extends Specification {
         run().task(':run').outcome == TaskOutcome.SUCCESS
     }
 
+    def "can add static/transitive 'requires' modifiers to legacy libraries"() {
+        given:
+        new File(testFolder.root, "src/main/java/org/gradle/sample/app/data").mkdirs()
+
+        testFolder.newFile("src/main/java/org/gradle/sample/app/Main.java") << """
+            package org.gradle.sample.app;
+            
+            import static java.lang.module.ModuleDescriptor.Requires;
+            import static java.util.function.Function.identity;
+            
+            import java.lang.module.ModuleDescriptor;
+            import java.util.Map;
+            import java.util.stream.Collectors;
+            
+            public class Main {
+            
+                public static void main(String[] args) {
+                    Map<String, Requires> index = ModuleLayer.boot()
+                            .findModule("spring.boot.autoconfigure")
+                            .map(Module::getDescriptor)
+                            .map(ModuleDescriptor::requires)
+                            .orElseThrow(() -> new AssertionError("Cannot find spring.boot.autoconfigure"))
+                            .stream()
+                            .collect(Collectors.toMap(Requires::name, identity()));
+                    if (!index.get("spring.boot").modifiers().contains(Requires.Modifier.TRANSITIVE)) {
+                        throw new AssertionError("spring.boot must be declared as transitive");
+                    }
+                    if (!index.get("com.google.gson").modifiers().contains(Requires.Modifier.STATIC)) {
+                        throw new AssertionError("com.google.gson must be declared as static");
+                    }
+                    if (!index.get("spring.context").modifiers().isEmpty()) {
+                        throw new AssertionError("spring.boot must not have any modifiers");
+                    }
+                }
+            
+            }
+        """
+        testFolder.newFile("src/main/java/module-info.java") << """
+            module org.gradle.sample.app {               
+                requires spring.boot.autoconfigure;
+            }
+        """
+        testFolder.newFile("build.gradle.kts") << """
+            plugins {
+                application
+                id("de.jjohannes.extra-java-module-info")
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            java {
+                modularity.inferModulePath.set(true)
+            }
+            
+            dependencies {
+                implementation("org.springframework.boot:spring-boot-autoconfigure:2.4.2") 
+            }
+            
+            extraJavaModuleInfo {               
+                module("spring-boot-autoconfigure-2.4.2.jar", "spring.boot.autoconfigure", "2.4.2") {
+                    requires("spring.context")
+                    requiresTransitive("spring.boot")
+                    requiresStatic("com.google.gson")
+                }
+            }
+                                 
+            application {
+                mainModule.set("org.gradle.sample.app")
+                mainClass.set("org.gradle.sample.app.Main")
+            }
+        """
+
+        expect:
+        run().task(':run').outcome == TaskOutcome.SUCCESS
+    }
+
     def "fails by default if no module info is defined for a legacy library"() {
         given:
         new File(testFolder.root, "src/main/java").mkdirs()

--- a/src/main/java/de/jjohannes/gradle/javamodules/ExtraModuleInfoTransform.java
+++ b/src/main/java/de/jjohannes/gradle/javamodules/ExtraModuleInfoTransform.java
@@ -197,6 +197,9 @@ abstract public class ExtraModuleInfoTransform implements TransformAction<ExtraM
         for (String requireName : moduleInfo.getRequiresTransitive()) {
             moduleVisitor.visitRequire(requireName, Opcodes.ACC_TRANSITIVE, null);
         }
+        for (String requireName : moduleInfo.getRequiresStatic()) {
+            moduleVisitor.visitRequire(requireName, Opcodes.ACC_STATIC_PHASE, null);
+        }
         for (Map.Entry<String, Set<String>> entry : providers.entrySet()) {
             String provider = entry.getKey();
             String[] implementations = entry.getValue()

--- a/src/main/java/de/jjohannes/gradle/javamodules/ModuleInfo.java
+++ b/src/main/java/de/jjohannes/gradle/javamodules/ModuleInfo.java
@@ -28,6 +28,7 @@ public class ModuleInfo implements Serializable {
     private List<String> exports = new ArrayList<>();
     private List<String> requires = new ArrayList<>();
     private List<String> requiresTransitive = new ArrayList<>();
+    private List<String> requiresStatic = new ArrayList<>();
 
     ModuleInfo(String moduleName, String moduleVersion) {
         this.moduleName = moduleName;
@@ -44,6 +45,10 @@ public class ModuleInfo implements Serializable {
 
     public void requiresTransitive(String requiresTransitive) {
         this.requiresTransitive.add(requiresTransitive);
+    }
+
+    public void requiresStatic(String requiresStatic) {
+        this.requiresStatic.add(requiresStatic);
     }
 
     public String getModuleName() {
@@ -64,5 +69,9 @@ public class ModuleInfo implements Serializable {
 
     protected List<String> getRequiresTransitive() {
         return requiresTransitive;
+    }
+
+    protected List<String> getRequiresStatic() {
+        return requiresStatic;
     }
 }


### PR DESCRIPTION
These are two uses cases I ran into while trying to modularize a small Spring Boot project.

* `provides ... with`. If a JAR file has module-info.class, any SPI implementations declared in META-INF/services/* are not visible to `java.util.ServiceLoader`. Fortunately, this issue can be fixed by automatically translating this metadata into `module-info.class` `provides` entries.
* `requires static`. Spring Boot heavily exploits this concept of "optional dependencies" in `auto-configurations`. Later on, these optional dependencies are brought to the dependency graph by the `starter` libraries. The latter can be covered by `requires` whilst the former is not supported by the plugin.

Let me know if you'd like me to split this PR into two separate PRs or if you have any suggestions on how the implementation/test cases could be improved.