### PR TITLE
Exlude signatures from signed jars

### DIFF
--- a/src/main/java/de/jjohannes/gradle/javamodules/ExtraModuleInfoTransform.java
+++ b/src/main/java/de/jjohannes/gradle/javamodules/ExtraModuleInfoTransform.java
@@ -47,6 +47,7 @@ import java.util.zip.ZipEntry;
 abstract public class ExtraModuleInfoTransform implements TransformAction<ExtraModuleInfoTransform.Parameter> {
 
     private static final Pattern MODULE_INFO_CLASS_MRJAR_PATH = Pattern.compile("META-INF/versions/\\d+/module-info.class");
+    private static final Pattern JAR_SIGNATURE_PATH = Pattern.compile("^META-INF/[^/]+\\.(SF|RSA|DSA|sf|rsa|dsa)$");
     private static final String SERVICES_PREFIX = "META-INF/services/";
 
     public interface Parameter extends TransformParameters {
@@ -178,9 +179,11 @@ abstract public class ExtraModuleInfoTransform implements TransformAction<ExtraM
             if (entryName.startsWith(SERVICES_PREFIX) && !entryName.equals(SERVICES_PREFIX)) {
                 providers.put(entryName.substring(SERVICES_PREFIX.length()), extractImplementations(content));
             }
-            outputStream.putNextEntry(jarEntry);
-            outputStream.write(content);
-            outputStream.closeEntry();
+            if (!JAR_SIGNATURE_PATH.matcher(jarEntry.getName()).matches()) {
+                outputStream.putNextEntry(jarEntry);
+                outputStream.write(content);
+                outputStream.closeEntry();
+            }
             jarEntry = inputStream.getNextJarEntry();
         }
         return providers;


### PR DESCRIPTION
When transforming a signed jar we need to make sure the signature is removed when the manifest is modified.
Otherwise we can get errors like this:
```
> Task :my-application:run FAILED
Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for ...\.gradle\caches\transforms-3\...\transformed\org.eclipse.paho.client.mqttv3-1.2.5-module.jar
Caused by: java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
```
It might be rare to find a signed jar (without an existing module-info or automatic module name) so here is an example to test with:
```
extraJavaModuleInfo {
    automaticModule("org.eclipse.paho.client.mqttv3-1.2.5.jar", "org.eclipse.paho.client.mqttv3")
}
dependencies {
    implementation("org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5")
}
````
(https://repo1.maven.org/maven2/org/eclipse/paho/org.eclipse.paho.client.mqttv3/1.2.5/)

(Ported from MrcJkb/module-finder#6)