### PR TITLE
Support 'group:name' notation for compile-only dependencies

### DIFF
--- a/src/main/java/de/jjohannes/gradle/javamodules/ExtraModuleInfoPlugin.java
+++ b/src/main/java/de/jjohannes/gradle/javamodules/ExtraModuleInfoPlugin.java
@@ -59,8 +59,11 @@ public class ExtraModuleInfoPlugin implements Plugin<Project> {
                     m.getMergedJars().stream()).filter(s -> s.contains(":")).forEach(s ->
                     d.add(project.getDependencies().create(s))));
 
-            // Automatically get versions from the runtime classpath
+            // Automatically get versions from the compile and runtime classpath
             if (GradleVersion.current().compareTo(GradleVersion.version("6.8")) >= 0) {
+                //noinspection UnstableApiUsage
+                c.shouldResolveConsistentlyWith(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+
                 //noinspection UnstableApiUsage
                 c.shouldResolveConsistentlyWith(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             }

--- a/src/test/groovy/de/jjohannes/gradle/javamodules/test/ConfigurationDetailsFunctionalTest.groovy
+++ b/src/test/groovy/de/jjohannes/gradle/javamodules/test/ConfigurationDetailsFunctionalTest.groovy
@@ -214,12 +214,16 @@ class ConfigurationDetailsFunctionalTest extends Specification {
             module org.gradle.sample.app {
                 requires org.apache.commons.cli;
                 requires org.apache.commons.collections;
+                
+                requires static jsr305;
             }
         """
         buildFile << """
             dependencies {
                 implementation("commons-cli:commons-cli:1.4")  
                 implementation("commons-collections:commons-collections:3.2.2")
+                
+                compileOnly("com.google.code.findbugs:jsr305:3.0.2")
             }
             
             extraJavaModuleInfo {
@@ -227,6 +231,8 @@ class ConfigurationDetailsFunctionalTest extends Specification {
                     exports("org.apache.commons.cli")
                 }
                 module("${libs.commonsCollections}", "org.apache.commons.collections")
+
+                automaticModule("${libs.jsr305}", "jsr305")
             }
         """
 

--- a/src/test/groovy/de/jjohannes/gradle/javamodules/test/fixture/LegacyLibraries.groovy
+++ b/src/test/groovy/de/jjohannes/gradle/javamodules/test/fixture/LegacyLibraries.groovy
@@ -15,6 +15,7 @@ class LegacyLibraries {
     def commonsLogging = jarNameOnly ? "commons-logging-1.2.jar" : "commons-logging:commons-logging"
     def groovyAll = jarNameOnly ? "groovy-all-2.4.15.jar" : "org.codehaus.groovy:groovy-all"
     def javaxInject = jarNameOnly ? "javax.inject-1.jar" : "javax.inject:javax.inject"
+    def jsr305 = jarNameOnly ? "jsr305-3.0.2.jar" : "com.google.code.findbugs:jsr305"
     def log4jCore = jarNameOnly ? "log4j-core-2.14.0.jar" : "org.apache.logging.log4j:log4j-core"
     def sac = jarNameOnly ? "sac-1.3.jar" : "org.w3c.css:sac"
     def slf4jApi = jarNameOnly ? "slf4j-api-1.7.32.jar" : "org.slf4j:slf4j-api"


### PR DESCRIPTION
329293473e9bd22417176f2c68293b66608a3e38 added support for the convenient 'group:name' notation instead of the file name. This commit extends this functionality to also work for dependencies that are not in the runtime classpath (i.e. statically required modules).